### PR TITLE
Add unique attribute for Section Schema DSs.

### DIFF
--- a/data-sources/datasource.section_schema.php
+++ b/data-sources/datasource.section_schema.php
@@ -124,6 +124,8 @@
 		public function grab(array $param_pool) {
 			$result = new XMLElement($this->dsParamROOTELEMENT);
 
+			$result->setAttribute('type','section-schema');
+
 			// retrieve this section
 			$section_id = SectionManager::fetchIDFromHandle($this->dsParamSECTION);
 		  	$section = SectionManager::fetch($section_id);


### PR DESCRIPTION
Section Schemas Datasources should have an attribute `type` with value set to `section-schema` or something.

Use case:

I have several DSs attached to a page that return the schema of sections and I want to select a specific Datasource by section ID:

```
<xsl:copy-of select="/data/*[ @id = $section_id ]"/>
```

All good, but what if another Datasource that is not Section Schema type will have an attribute `id` with value equal to `$section_id`? That would be a conflict and above code will generate undesired results.

In the spirit of defensive coding, I suggest merging the above commit, thus resulting in this XSLT code:

```
<xsl:copy-of select="/data/*[ @type = 'section-schema' and @id = $section_id ]"/>
```

Future safe.
