### PR TITLE
Correct count() test in prepare()

### DIFF
--- a/data-sources/datasource.section_schema.php
+++ b/data-sources/datasource.section_schema.php
@@ -116,7 +116,7 @@
 			return sprintf($template,
 				$params['rootelement'],
 				$settings[self::getClass()]['section'],
-				count($settings[self::getClass()]['fields'] > 0) ? "'" . implode("','", $settings[self::getClass()]['fields']) . "'" : ''
+				(count($settings[self::getClass()]['fields']) > 0) ? "'" . implode("','", $settings[self::getClass()]['fields']) . "'" : ''
 			);
 		}
 


### PR DESCRIPTION
Put `> 0` outside `count()` and wrap in parentheses for correct boolean test.  Discovered when PHP7.2+ threw an error like "`count()`: Parameter must be an array or an object that implements Countable" when trying to create a data source on a field like the core text input field.